### PR TITLE
Fix notification timestamp parsing

### DIFF
--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -26,8 +26,12 @@ class FStoreNotification {
       body = notification['body'];
       title = notification['title'];
       seen = false;
-      int time = notification['google.sent_time'] ?? ['from'];
-      date = (new DateTime.fromMillisecondsSinceEpoch(time)).toString();
+      int time = notification['google.sent_time'] ?? json['google.sent_time'] ?? 0;
+      if (time != 0) {
+        date = DateTime.fromMillisecondsSinceEpoch(time).toString();
+      } else {
+        date = DateTime.now().toString();
+      }
       print(date);
     } catch (e) {
       print(e.toString());


### PR DESCRIPTION
## Summary
- fix parsing of `google.sent_time` field in notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f504197848322b373d67d43a8b348